### PR TITLE
:bug: Get compatibility before eslint@6.6.0.

### DIFF
--- a/rules/no-imports.js
+++ b/rules/no-imports.js
@@ -19,7 +19,7 @@ module.exports = {
     ]
   },
   create(context) {
-    const filename = path.relative(context.getCwd(), context.getFilename());
+    const filename = path.relative(process.cwd(), context.getFilename());
     const option = context.options[0];
 
     const roots =


### PR DESCRIPTION
Context#getCwd() is available from eslint@6.6.0
so use process.cwd() instead.